### PR TITLE
Improve missing report file error message

### DIFF
--- a/gracken/gracken.py
+++ b/gracken/gracken.py
@@ -108,8 +108,14 @@ def main():
 
     matching_files = glob.glob(os.path.join(args.input_dir, file_pattern))
     if not matching_files:
-        print(f"Error: No {args.mode} files found in {args.input_dir}", file=sys.stderr)
+        mode_label = "Bracken" if args.mode == "bracken" else "Kraken2"
+        print(
+            f"No {mode_label} report files found in: {args.input_dir}\n"
+            f"Expected file extension: {file_pattern}",
+            file=sys.stderr,
+        )
         sys.exit(1)
+
 
     for f in matching_files:
         name = os.path.splitext(os.path.basename(f))[0]


### PR DESCRIPTION
Hey @jonasoh ,
Thanks for developing Gracken.
When I first tried to use the tool, I ran into the error:
- No bracken files found
- No kraken2 files found

Later, through an issue thread, I understood that the tool expects files to end with `.breport `or `.k2report,` but the error message itself doesn’t mention these extensions.

This PR adds a clearer error message that includes the expected patterns (*.breport and *.k2report).
It doesn’t change any functionality,  just a small usability improvement.